### PR TITLE
getContactsByPhoneNumber tested on ios and android

### DIFF
--- a/App.js
+++ b/App.js
@@ -244,6 +244,25 @@ export default class RNContactsTest extends Component {
     });
   };
 
+  getContactsByPhoneNumber = () => {
+    const newContact = this._contact();
+    console.log("getContactsByPhoneNumber: starting", newContact);
+    Contacts.addContact(newContact, (error, addedContact) => {
+      Contacts.getContactsByPhoneNumber(
+        addedContact.phoneNumbers[0].number,
+        (err, data) => {
+          if (err) {
+            throw err;
+          }
+          for (let i = 0; i < data.length; i++) {
+            const item = data[i];
+            console.log("getContactsByPhoneNumber:", item);
+          }
+        }
+      );
+    });
+  };
+
   deleteContact = () => {
     Contacts.getAll((err, contactsBefore) => {
       const contactToDelete = _.find(
@@ -486,6 +505,12 @@ export default class RNContactsTest extends Component {
           title="get contacts matching string"
           onPress={this.getContactsMatchingString}
         />
+
+        <Button
+          title="get contacts by phone number"
+          onPress={this.getContactsByPhoneNumber}
+        />
+
         <Button title="getPhotoForId" onPress={this.getPhotoForId} />
         <Button title="add contact" onPress={this.addContact} />
         <Button title="update contact" onPress={this.updateContact} />

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "react": "16.8.3",
     "react-native": "0.59.1",
-    "react-native-contacts": "^3.1.4"
+    "react-native-contacts": "https://github.com/hatemalimam/react-native-contacts.git#feature/getContactsByPhoneNumber"
   },
   "devDependencies": {
     "@babel/core": "^7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,10 +4995,9 @@ react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-react-native-contacts@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-native-contacts/-/react-native-contacts-3.1.4.tgz#9db6e39c319f4960182e273ce48e8f8db7e5f799"
-  integrity sha512-6R2hexlmmQWLa7EiSco4e//GcY2lYRMRACRC1okKwB2ApbPoDnPAo61bNjp+zIKcMF8eBsjCh0rSqPlD6wI6yg==
+"react-native-contacts@https://github.com/hatemalimam/react-native-contacts.git#feature/getContactsByPhoneNumber":
+  version "5.0.2"
+  resolved "https://github.com/hatemalimam/react-native-contacts.git#804303f141d6f83903c9e4373929d938dc75647f"
 
 react-native@0.59.1:
   version "0.59.1"


### PR DESCRIPTION
after accepting this PR https://github.com/rt2zz/react-native-contacts/pull/416
the dependency should be pointed back to the original npm destination.

in this branch `getContactsByPhoneNumber` is tested on both platforms.